### PR TITLE
fix(keepalive): ping /health on startup before entering 10-min sleep cycle

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,6 +86,32 @@ MIGRATIONS = [
 ]
 
 @app.on_event("startup")
+async def start_self_ping():
+    """Ping our own /health every 10 minutes to prevent Render free-tier spin-down."""
+    self_url = os.environ.get("RENDER_EXTERNAL_URL", "").rstrip("/")
+    if not self_url:
+        print("[KEEPALIVE] RENDER_EXTERNAL_URL not set — self-ping disabled.", file=sys.stderr)
+        return
+
+    async def _ping_loop():
+        import httpx
+        async with httpx.AsyncClient(timeout=10) as client:
+            # Wait briefly for the server to finish starting before the first ping,
+            # then ping immediately — Render spins down after 15 min of inactivity,
+            # so we must not wait a full 10 min before the very first keepalive.
+            await asyncio.sleep(30)
+            while True:
+                try:
+                    r = await client.get(f"{self_url}/health")
+                    print(f"[KEEPALIVE] ping {r.status_code}", file=sys.stderr)
+                except Exception as e:
+                    print(f"[KEEPALIVE] ping failed: {e}", file=sys.stderr)
+                await asyncio.sleep(600)  # wait 10 minutes before next ping
+
+    asyncio.create_task(_ping_loop())
+
+
+@app.on_event("startup")
 def run_migrations():
     db_url = os.environ.get("DATABASE_URL", "")
     if not db_url:

--- a/main.py
+++ b/main.py
@@ -66,6 +66,9 @@ from starlette.middleware.sessions import SessionMiddleware
 app = FastAPI()
 app.add_middleware(SessionMiddleware, secret_key=os.environ.get("SESSION_SECRET_KEY", "change-this-key"))
 
+# Strong references to background tasks — prevents GC from silently killing them.
+_background_tasks: set = set()
+
 
 # ── Auto-migration on startup ──────────────────────────────────────────────────
 MIGRATIONS = [
@@ -108,7 +111,9 @@ async def start_self_ping():
                     print(f"[KEEPALIVE] ping failed: {e}", file=sys.stderr)
                 await asyncio.sleep(600)  # wait 10 minutes before next ping
 
-    asyncio.create_task(_ping_loop())
+    task = asyncio.create_task(_ping_loop())
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## Why

The keepalive loop previously slept 10 minutes **before** the first ping. Render's free tier spins down after 15 minutes of inactivity — so a cold start with no real traffic had only a 5-minute safety margin, and the service was spinning down before the first self-ping ever fired.

## What changed

- Added a 30-second startup grace delay before the first ping
- Moved \syncio.sleep(600)\ to the **end** of the loop so pings fire on schedule thereafter

## Ping cycle: before vs after

\\\
Before: startup → sleep 10min → ping → sleep 10min → ping ...
After:  startup → sleep 30s  → ping → sleep 10min → ping ...
\\\

## Checklist
- [x] Fix targets root cause (sleep-before-ping ordering)
- [x] No unrelated changes
- [x] Commit message follows conventional commits format