### PR TITLE
fix: pre-commit test gate no longer blocks every new Python file

### DIFF
--- a/.forge/hooks/pre-commit
+++ b/.forge/hooks/pre-commit
@@ -34,8 +34,14 @@ source_files=$(echo "$staged_files" | grep -E '\.(go|js|jsx|ts|tsx|py|rs|java|cs
 new_source_files=$(git diff --cached --name-only --diff-filter=A 2>/dev/null | grep -E '\.(go|js|jsx|ts|tsx|py|rs|java|cs)$' | grep -vE '^(cmd/forge/web/|frontend/dist/|static/assets/|bin/)')
 if [[ -n "$new_source_files" ]]; then
     while IFS= read -r new_file; do
-        # Skip files that are themselves test files
+        # Skip files that are themselves test files.
+        # Python is the exception to suffix matching: pytest's dominant convention
+        # puts "test_" at the FRONT of the filename (test_api.py), so a suffix-only
+        # check reads a test file as untested source and blocks the commit.
         if echo "$new_file" | grep -qE '(_test\.go|\.test\.(js|jsx|ts|tsx)|\.spec\.(js|jsx|ts|tsx)|_test\.py|_test\.rs)$'; then
+            continue
+        fi
+        if echo "$new_file" | grep -qE '(^|/)test_[^/]*\.py$'; then
             continue
         fi
         extension="${new_file##*.}"
@@ -46,6 +52,21 @@ if [[ -n "$new_source_files" ]]; then
             if echo "$staged_files" | grep -qF "$expected_test" || [[ -f "$expected_test" ]]; then
                 has_test=true
             fi
+        elif [[ "$extension" == "py" ]]; then
+            # Python: pytest discovers both test_<name>.py and <name>_test.py.
+            # Without this branch a new .py file falls through to the JS/TS check
+            # below and is searched for "foo.test.py", which is not a convention in
+            # any Python project — so no new Python file could ever pass this gate.
+            module_dir=$(dirname "$new_file")
+            module_name=$(basename "$base_name")
+            [[ "$module_dir" == "." ]] && module_dir=""
+            for candidate in "test_${module_name}.py" "${module_name}_test.py"; do
+                expected_test="${module_dir:+${module_dir}/}${candidate}"
+                if echo "$staged_files" | grep -qF "$expected_test" || [[ -f "$expected_test" ]]; then
+                    has_test=true
+                    break
+                fi
+            done
         else
             # JS/TS: check for .test and .spec variants
             for test_suffix in ".test.${extension}" ".spec.${extension}"; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,5 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the config type with the `test` property required by Vitest.
 - Pre-commit hook now correctly excludes `static/assets/` from the "new source
   file must have a test" gate (compiled bundles are not authored source code).
+- Pre-commit "new source file must have a test" gate no longer blocks every new
+  Python file. It matched test files by suffix only (`_test.py`), so pytest's
+  standard `test_*.py` prefix — the convention this repo already uses in
+  `test_api.py` and `test_local.py` — was read as untested source. The gate also
+  sent non-Go files down a JS/TS branch that looked for `foo.test.py`, which is
+  not a Python convention, so no new `.py` file could ever satisfy it.
 
 ### Removed


### PR DESCRIPTION
## Problem

Found while committing the Supabase keepalive fix (#11). The pre-commit "new source file must have a test" gate rejected `test_keepalive.py` — a test file — for *not having a test file*.

Two separate defects:

**1. Suffix-only matching.** The gate recognised `_test.py`, but pytest's dominant convention puts `test_` at the *front* of the filename. This repo already uses that convention (`test_api.py`, `test_local.py`), so any new test file was read as untested source.

**2. No Python branch at all.** Every non-Go file fell through to a JS/TS branch that searched for `foo.test.py` / `foo.spec.py`. Neither is a convention in any Python project — so **no new `.py` file could ever satisfy this gate**, regardless of naming. The only escape was `--no-verify`, which defeats the purpose of the gate.

## Fix

- Treat `test_*.py` as a test file, alongside the existing `_test.py`.
- Add a Python branch checking both `test_<name>.py` and `<name>_test.py`, matching what pytest actually discovers.

## Note

The `.ps1` twin (`.forge/hooks/pre-commit.ps1`) has the same two defects and I applied the same fix locally, but that file is untracked in this repo so it is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)