### PR TITLE
docs: cut the v2026.8.29 release section in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [2026.8.29] - 2026-08-29
+
 ### Added
 - Forge Workflow initialized with Forge Terminal Workflow Architect
 - React + TypeScript + Vite frontend replacing the vanilla `send.html` implementation.


### PR DESCRIPTION
Moves everything under `## [Unreleased]` into a dated `## [2026.8.29]` heading ahead of tagging, and reopens `Unreleased` empty.

Documentation only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8EEwPPVW17FxiHKcmVW1e